### PR TITLE
Moved configuration phase via `init` method, per JavaEE javadoc recommendation.

### DIFF
--- a/src/main/java/org/webjars/servlet/WebjarsServlet.java
+++ b/src/main/java/org/webjars/servlet/WebjarsServlet.java
@@ -37,7 +37,11 @@ public class WebjarsServlet extends HttpServlet {
     private boolean disableCache = false;
 
     @Override
-    public void init(ServletConfig config) throws ServletException {
+    public void init() throws ServletException {
+        ServletConfig config = getServletConfig();
+        if(config == null) {
+            throw new NullPointerException("Expected servlet container to provide a non-null ServletConfig.");
+        }
         try {
             String disableCache = config.getInitParameter("disableCache");
             if (disableCache != null) {


### PR DESCRIPTION
See [GenericServlet.html#init](https://docs.oracle.com/javaee/6/api/javax/servlet/GenericServlet.html#init%28javax.servlet.ServletConfig%29) for details on overriding `GenericServlet`'s implementation.
