### PR TITLE
Set the level of resource requested logging to FINE

### DIFF
--- a/src/main/java/org/webjars/servlet/WebjarsServlet.java
+++ b/src/main/java/org/webjars/servlet/WebjarsServlet.java
@@ -59,7 +59,7 @@ public class WebjarsServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         String webjarsResourceURI = "/META-INF/resources" + request.getRequestURI().replaceFirst(request.getContextPath(), "");
-        logger.log(Level.INFO, "Webjars resource requested: " + webjarsResourceURI);
+        logger.log(Level.FINE, "Webjars resource requested: " + webjarsResourceURI);
         
         String eTagName = this.getETagName(webjarsResourceURI);
         

--- a/src/main/java/org/webjars/servlet/WebjarsServlet.java
+++ b/src/main/java/org/webjars/servlet/WebjarsServlet.java
@@ -60,6 +60,7 @@ public class WebjarsServlet extends HttpServlet {
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         String webjarsResourceURI = "/META-INF/resources" + request.getRequestURI().replaceFirst(request.getContextPath(), "");
         logger.log(Level.FINE, "Webjars resource requested: {0}", webjarsResourceURI);
+        
         String eTagName = this.getETagName(webjarsResourceURI);
         
         if (!disableCache) {


### PR DESCRIPTION
Hi, Thank you for the maintaining WebJars, I pretty love it. I'm a committer of Apache Roller, Java EE blog engine https://roller.apache.org and planning to use WebJars from the next release of Roller.

I think the following log is too chatty that produced every time at any requests have come.

```
13-Dec-2015 15:16:33.687 INFO [http-nio-8080-exec-11] org.webjars.servlet.WebjarsServlet.doGet Webjars resource requested: /META-INF/resources/webjars/angular/1.2.29/angular.min.js.map
```

Also our users may feel the above log is too chatty so I may need to add a note to our installation guide that something like "please put `org.webjars.level = WARNING` in your `logging.properties` of the container".

So, I propose that setting the logging level to `FINE` instead of `INFO`. What do you think?
